### PR TITLE
Revert "Bump kramdown from 2.1.0 to 2.3.0"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,8 +41,7 @@ GEM
       nuggets
     jekyll-watch (2.2.1)
       listen (~> 3.0)
-    kramdown (2.3.0)
-      rexml
+    kramdown (2.1.0)
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
     liquid (4.0.3)
@@ -58,7 +57,6 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    rexml (3.2.4)
     rouge (3.9.0)
     ruby_dep (1.5.0)
     safe_yaml (1.0.5)


### PR DESCRIPTION
Reverts IvLabs/ivlabs.github.io#1